### PR TITLE
initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/bower_components/
+/node_modules/
+/.pulp-cache/
+/output/
+/.psci*
+/src/.webpack.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+sudo: false
+node_js:
+  - 4
+install:
+  - npm install bower -g
+  - npm install && bower install
+script:
+  - pulp test
+after_success:
+- >-
+  test $TRAVIS_TAG &&
+  psc-publish > .pursuit.json &&
+  curl -X POST http://pursuit.purescript.org/packages \
+    -d @.pursuit.json \
+    -H 'Accept: application/json' \
+    -H "Authorization: token ${GITHUB_TOKEN}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+### `purescript-decimals`
+
+This is a library for doing exact computation with decimal numbers of finite
+expansion (i.e. numbers that can be represented in the form `m * 10^n`).
+
+See the [Documentation](./docs/Data/Decimal.md). The laws of each numerical
+type class ascribed by `Decimal` are checked using StrongCheck.

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "purescript-arrays": "^0.4.5",
+    "purescript-bigints": "^0.2.1",
     "purescript-console": "^0.1.0",
     "purescript-orders": "^0.1.1",
     "purescript-prelude": "^0.1.4",

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "purescript-decimals",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/slamdata/purescript-decimals.git"
+  },
+  "authors": [
+    "Jon Sterling <jon@jonmsterling.com>"
+  ],
+  "license": "Apache-2.0",
+  "moduleType": [
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-arrays": "^0.4.5",
+    "purescript-console": "^0.1.0",
+    "purescript-orders": "^0.1.1",
+    "purescript-prelude": "^0.1.4",
+    "purescript-strings": "^0.7.1",
+    "purescript-strongcheck": "^0.14.7"
+  }
+}

--- a/docs/Data/Decimal.md
+++ b/docs/Data/Decimal.md
@@ -1,0 +1,61 @@
+## Module Data.Decimal
+
+#### `Decimal`
+
+``` purescript
+newtype Decimal
+```
+
+An abstract type for exact computing with decimal numbers of finite expansion.
+
+##### Instances
+``` purescript
+Show Decimal
+Eq Decimal
+Ord Decimal
+Arbitrary Decimal
+Semiring Decimal
+Ring Decimal
+```
+
+#### `prettyDecimal`
+
+``` purescript
+prettyDecimal :: Decimal -> String
+```
+
+#### `decimal`
+
+``` purescript
+decimal :: Int -> Int -> Decimal
+```
+
+Construct a decimal number from a mantissa and an exponent.
+For example, `decimal 34 96` becomes `34e96` and `decimal 20 1`
+becomes `2e2`.
+
+#### `getMantissa`
+
+``` purescript
+getMantissa :: Decimal -> Int
+```
+
+Get the mantissa (or significand) from a decimal number.
+
+#### `getExponent`
+
+``` purescript
+getExponent :: Decimal -> Int
+```
+
+Get the exponent from a decimal number.
+
+#### `fromInt`
+
+``` purescript
+fromInt :: Int -> Decimal
+```
+
+The integers embed into the decimals.
+
+

--- a/docs/Data/Decimal.md
+++ b/docs/Data/Decimal.md
@@ -27,17 +27,25 @@ prettyDecimal :: Decimal -> String
 #### `decimal`
 
 ``` purescript
-decimal :: Int -> Int -> Decimal
+decimal :: BigInt -> Int -> Decimal
 ```
 
-Construct a decimal number from a mantissa and an exponent.
+Construct a decimal number from a `BigInt` mantissa and an exponent.
 For example, `decimal 34 96` becomes `34e96` and `decimal 20 1`
 becomes `2e2`.
+
+#### `decimal'`
+
+``` purescript
+decimal' :: Int -> Int -> Decimal
+```
+
+The same as `decimal`, except that the mantissa is an `Int`.
 
 #### `getMantissa`
 
 ``` purescript
-getMantissa :: Decimal -> Int
+getMantissa :: Decimal -> BigInt
 ```
 
 Get the mantissa (or significand) from a decimal number.
@@ -48,7 +56,7 @@ Get the mantissa (or significand) from a decimal number.
 getExponent :: Decimal -> Int
 ```
 
-Get the exponent from a decimal number.
+Get the places from a decimal number.
 
 #### `fromInt`
 
@@ -57,5 +65,11 @@ fromInt :: Int -> Decimal
 ```
 
 The integers embed into the decimals.
+
+#### `fromBigInt`
+
+``` purescript
+fromBigInt :: BigInt -> Decimal
+```
 
 

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "devDependencies": {
     "pulp": "^8.1.0",
     "purescript": "^0.7.6"
+  },
+  "dependencies": {
+    "big-integer": "^1.6.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "devDependencies": {
+    "pulp": "^8.1.0",
+    "purescript": "^0.7.6"
+  }
+}

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -29,11 +29,16 @@ newtype Decimal = Decimal DecimalR
 instance showDecimal :: Show Decimal where
   show (Decimal d) =
     "decimal "
-      <> show d.mantissa
+      <> showInt d.mantissa
       <> " "
-      <> if d.exponent > 0
-         then show d.exponent
-         else "(" <> show d.exponent <> ")"
+      <> showInt d.exponent
+    where
+      showInt i =
+        if i > 0
+        then show i
+        else "(" <> show i <> ")"
+
+
 
 instance eqDecimal :: Eq Decimal where
   eq (Decimal d1) (Decimal d2) =

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -116,8 +116,8 @@ normalize =
 
 instance arbitraryDecimal :: SC.Arbitrary Decimal where
   arbitrary = do
-    mantissa <- BI.fromInt <$> Gen.chooseInt (-100.0) 100.0
-    places <- Gen.chooseInt (-20.0) 20.0
+    mantissa <- BI.fromInt <$> Gen.chooseInt (-100000.0) 100000.0
+    places <- Gen.chooseInt (-200.0) 200.0
     pure $ normalize { mantissa, places }
 
 instance semiringDecimal :: Semiring Decimal where

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -113,8 +113,8 @@ normalize =
 
 instance arbitraryDecimal :: SC.Arbitrary Decimal where
   arbitrary = do
-    mantissa <- Gen.chooseInt 0.0 10000000000000000.0
-    exponent <- Gen.chooseInt 0.0 1000.0
+    mantissa <- Gen.chooseInt (-100.0) 100.0
+    exponent <- Gen.chooseInt (-20.0) 20.0
     pure $ normalize { mantissa, exponent }
 
 instance semiringDecimal :: Semiring Decimal where

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -1,0 +1,189 @@
+module Data.Decimal
+  ( Decimal()
+  , decimal
+  , getMantissa
+  , getExponent
+  , fromInt
+  , prettyDecimal
+  ) where
+
+import Prelude
+import Data.Array as A
+import Data.Either as E
+import Data.Maybe as M
+import Data.Ord as O
+import Data.String as S
+import Control.Monad.Rec.Class as Rec
+
+import Test.StrongCheck as SC
+import Test.StrongCheck.Gen as Gen
+
+type DecimalR =
+  { mantissa :: Int
+  , exponent :: Int
+  }
+
+-- | An abstract type for exact computing with decimal numbers of finite expansion.
+newtype Decimal = Decimal DecimalR
+
+instance showDecimal :: Show Decimal where
+  show (Decimal d) =
+    "decimal "
+      <> show d.mantissa
+      <> " "
+      <> if d.exponent > 0
+         then show d.exponent
+         else "(" <> show d.exponent <> ")"
+
+instance eqDecimal :: Eq Decimal where
+  eq (Decimal d1) (Decimal d2) =
+    d1.mantissa == d2.mantissa
+      && (d1.exponent == d2.exponent || d1.mantissa == 0)
+
+instance ordDecimal :: Ord Decimal where
+  compare (Decimal d1) (Decimal d2) =
+    case compare d1.exponent d2.exponent of
+      EQ -> compare d1.mantissa d2.mantissa
+      o ->
+        if d1.mantissa == 0 && d2.mantissa == 0
+        then EQ
+        else o
+
+type Nat = Int
+
+pow
+  :: Int
+  -> Nat
+  -> Int
+pow i p =
+  Data.Int.floor $
+    Math.pow
+      (Data.Int.toNumber i)
+      (Data.Int.toNumber p)
+
+data SignedView a
+  = Pos a
+  | Neg a
+  | Zero
+
+signedView
+  :: Int
+  -> SignedView Nat
+signedView 0 =
+  Zero
+signedView n =
+  if n > 0
+  then Pos n
+  else Neg (- n)
+
+prettyDecimal
+  :: Decimal
+  -> String
+prettyDecimal (Decimal d) =
+  case d.mantissa of
+    0 -> "0"
+    _ ->
+      case signedView d.exponent of
+        Pos e -> show $ d.mantissa * pow 10 d.exponent
+        Neg e ->
+          let
+            m = show d.mantissa
+            zeroes = S.fromCharArray $ A.replicate (O.max 0 (e - S.length m)) '0'
+            arr = S.toCharArray $ zeroes <> m
+            i = A.length arr - e
+            arr' = M.fromMaybe [] $ A.insertAt i '.' arr
+            m' = S.fromCharArray arr'
+          in
+            if i == 0 then "0" <> m' else m'
+        Zero -> show d.mantissa
+
+normalize
+  :: DecimalR
+  -> Decimal
+normalize =
+  Rec.tailRec \d ->
+    if d.mantissa /= 0 && d.mantissa `mod` 10 == 0
+    then E.Left { mantissa : div d.mantissa 10, exponent : d.exponent + 1 }
+    else E.Right $ Decimal d
+
+instance arbitraryDecimal :: SC.Arbitrary Decimal where
+  arbitrary = do
+    mantissa <- Gen.chooseInt 0.0 10000000000000000.0
+    exponent <- Gen.chooseInt 0.0 1000.0
+    pure $ normalize { mantissa, exponent }
+
+instance semiringDecimal :: Semiring Decimal where
+  one =
+    Decimal
+      { mantissa : one
+      , exponent : zero
+      }
+
+  zero =
+    Decimal
+      { mantissa : zero
+      , exponent : zero
+      }
+
+  add (Decimal d1) (Decimal d2) =
+    normalize
+      { mantissa : change d1 + change d2
+      , exponent
+      }
+    where
+      exponent = O.max d1.exponent d2.exponent
+      change d = mul d.mantissa $ pow 10 (exponent - d.exponent)
+
+  mul (Decimal d1) (Decimal d2) =
+    normalize
+      { mantissa : d1.mantissa * d2.mantissa
+      , exponent : d1.exponent + d2.exponent
+      }
+
+negateDecimal
+  :: Decimal
+  -> Decimal
+negateDecimal (Decimal d) =
+  Decimal $ d { mantissa = - d.mantissa }
+
+instance ringDecimal :: Ring Decimal where
+  sub d1 d2 =
+    d1 + negateDecimal d2
+
+-- | Construct a decimal number from a mantissa and an exponent.
+-- | For example, `decimal 34 96` becomes `34e96` and `decimal 20 1`
+-- | becomes `2e2`.
+decimal
+  :: Int
+  -> Int
+  -> Decimal
+decimal mantissa exponent =
+  normalize
+    { mantissa
+    , exponent
+    }
+
+-- | Get the mantissa (or significand) from a decimal number.
+getMantissa
+  :: Decimal
+  -> Int
+getMantissa (Decimal d) =
+  d.mantissa
+
+
+-- | Get the exponent from a decimal number.
+getExponent
+  :: Decimal
+  -> Int
+getExponent (Decimal d) =
+  d.exponent
+
+-- | The integers embed into the decimals.
+fromInt
+  :: Int
+  -> Decimal
+fromInt i =
+  normalize
+    { mantissa : i
+    , exponent : 0
+    }

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -33,13 +33,26 @@ type DecimalR =
 -- | An abstract type for exact computing with decimal numbers of finite expansion.
 newtype Decimal = Decimal DecimalR
 
+-- | Get the mantissa (or significand) from a decimal number.
+getMantissa
+  :: Decimal
+  -> BI.BigInt
+getMantissa (Decimal d) =
+  d.mantissa
+
+-- | Get the places from a decimal number.
+getExponent
+  :: Decimal
+  -> Int
+getExponent (Decimal d) =
+  - d.places
 
 instance showDecimal :: Show Decimal where
-  show (Decimal d) =
+  show d =
     "decimal "
-      <> showInt d.mantissa
+      <> showInt (getMantissa d)
       <> " "
-      <> showInt d.places
+      <> showInt (getExponent d)
     where
       showInt :: forall i. (Show i, Ring i, Ord i) => i -> String
       showInt i =
@@ -223,20 +236,6 @@ decimal'
   -> Decimal
 decimal' =
   decimal <<< BI.fromInt
-
--- | Get the mantissa (or significand) from a decimal number.
-getMantissa
-  :: Decimal
-  -> BI.BigInt
-getMantissa (Decimal d) =
-  d.mantissa
-
--- | Get the places from a decimal number.
-getExponent
-  :: Decimal
-  -> Int
-getExponent (Decimal d) =
-  - d.places
 
 -- | The integers embed into the decimals.
 fromInt

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -1,9 +1,11 @@
 module Data.Decimal
   ( Decimal()
   , decimal
+  , decimal'
   , getMantissa
   , getExponent
   , fromInt
+  , fromBigInt
   , prettyDecimal
   ) where
 
@@ -15,12 +17,17 @@ import Data.Ord as O
 import Data.String as S
 import Control.Monad.Rec.Class as Rec
 
+import Data.BigInt as BI
+
 import Test.StrongCheck as SC
 import Test.StrongCheck.Gen as Gen
 
+-- This representation and some of the code is based on the `Decimal` Haskell
+-- package by Paul Johnson.
+
 type DecimalR =
-  { mantissa :: Int
-  , exponent :: Int
+  { mantissa :: BI.BigInt
+  , places :: Int
   }
 
 -- | An abstract type for exact computing with decimal numbers of finite expansion.
@@ -32,53 +39,29 @@ instance showDecimal :: Show Decimal where
     "decimal "
       <> showInt d.mantissa
       <> " "
-      <> showInt d.exponent
+      <> showInt d.places
     where
+      showInt :: forall i. (Show i, Ring i, Ord i) => i -> String
       showInt i =
-        if i > 0
+        if i > zero
         then show i
         else "(" <> show i <> ")"
-
-
 
 instance eqDecimal :: Eq Decimal where
   eq (Decimal d1) (Decimal d2) =
     d1.mantissa == d2.mantissa
-      && (d1.exponent == d2.exponent || d1.mantissa == 0)
+      && (d1.places == d2.places || d1.mantissa == zero)
 
 instance ordDecimal :: Ord Decimal where
   compare (Decimal d1) (Decimal d2) =
-    case compare d1.exponent d2.exponent of
+    case compare d1.places d2.places of
       EQ -> compare d1.mantissa d2.mantissa
       o ->
-        if d1.mantissa == 0 && d2.mantissa == 0
+        if d1.mantissa == zero && d2.mantissa == zero
         then EQ
         else o
 
 type Nat = Int
-
-pow
-  :: Int
-  -> Nat
-  -> Int
-pow i p =
-  Data.Int.floor $
-    Math.pow
-      (Data.Int.toNumber i)
-      (Data.Int.toNumber p)
---pow
---  :: Int
---  -> Nat
---  -> Int
---pow i p =
---  Rec.tailRec go { acc: 1, pwr : p }
---  where
---    go { acc, pwr } =
---      Debug.Trace.trace ("go " <> show pwr) \_ ->
---      case pwr of
---        0 -> E.Right acc
---        _ -> E.Left { acc: acc * i, pwr : pwr - 1 }
-
 
 data SignedView a
   = Pos a
@@ -88,69 +71,72 @@ data SignedView a
 signedView
   :: Int
   -> SignedView Nat
-signedView 0 =
-  Zero
-signedView n =
-  if n > 0
-  then Pos n
-  else Neg (- n)
+signedView i =
+  if i > zero
+  then Pos i
+  else if i == zero
+  then Zero
+  else Neg (i * -1)
 
 prettyDecimal
   :: Decimal
   -> String
 prettyDecimal (Decimal d) =
-  case d.mantissa of
-    0 -> "0"
-    _ ->
-      case signedView d.exponent of
-        Pos e -> show $ d.mantissa * pow 10 d.exponent
+  if d.mantissa == zero
+  then "0"
+  else
+    let
+      exponent = -d.places
+    in
+      case signedView exponent of
+        Pos e -> BI.toString $ d.mantissa * BI.pow (BI.fromInt 10) (BI.fromInt exponent)
         Neg e ->
           let
-            m = show d.mantissa
+            m = BI.toString d.mantissa
             m' = M.fromMaybe m $ S.stripPrefix "-" $ m
-            l = if d.mantissa > 0 then S.length m else S.length m' - 1
-            zeroes = S.fromCharArray $ A.replicate (O.max 0 (e - l)) '0'
+            l = if d.mantissa > zero then S.length m else S.length m' - 1
+            zeroes = S.fromCharArray $ A.replicate (O.max zero (e - l)) '0'
             arr = S.toCharArray $ zeroes <> m'
             i = A.length arr - e
             arr' = M.fromMaybe [] $ A.insertAt i '.' arr
             m'' = S.fromCharArray arr'
-            sign = if d.mantissa > 0 then "" else "-"
+            sign = if d.mantissa > zero then "" else "-"
           in
             sign <> if i == 0 then "0" <> m'' else m''
-        Zero -> show d.mantissa
+        Zero -> BI.toString d.mantissa
 
 normalize
   :: DecimalR
   -> Decimal
 normalize =
   Rec.tailRec \d ->
-    if d.mantissa /= 0 && d.mantissa `mod` 10 == 0
-    then E.Left { mantissa : div d.mantissa 10, exponent : d.exponent + 1 }
+    if d.mantissa /= zero && d.mantissa `mod` BI.fromInt 10 == zero
+    then E.Left { mantissa : div d.mantissa (BI.fromInt 10), places : d.places - 1 }
     else E.Right $ Decimal d
 
 instance arbitraryDecimal :: SC.Arbitrary Decimal where
   arbitrary = do
-    mantissa <- Gen.chooseInt (-100.0) 100.0
-    exponent <- Gen.chooseInt (-20.0) 20.0
-    pure $ normalize { mantissa, exponent }
+    mantissa <- BI.fromInt <$> Gen.chooseInt (-100.0) 100.0
+    places <- Gen.chooseInt (-20.0) 20.0
+    pure $ normalize { mantissa, places }
 
 instance semiringDecimal :: Semiring Decimal where
   one =
     Decimal
       { mantissa : one
-      , exponent : zero
+      , places : zero
       }
 
   zero =
     Decimal
       { mantissa : zero
-      , exponent : zero
+      , places : zero
       }
 
   add d1 d2 =
     normalize
       { mantissa : r.n1 + r.n2
-      , exponent : r.e
+      , places : r.e
       }
     where
       r = roundMax d1 d2
@@ -158,24 +144,24 @@ instance semiringDecimal :: Semiring Decimal where
   mul (Decimal d1) (Decimal d2) =
     normalize
       { mantissa : d1.mantissa * d2.mantissa
-      , exponent : d1.exponent + d2.exponent
+      , places : d1.places + d2.places
       }
 
--- is this right?
-divRound :: Int -> Int -> Int
+divRound :: BI.BigInt -> BI.BigInt -> BI.BigInt
 divRound n1 n2 =
-  if abs r * 2 >= abs n2
+  if abs r * BI.fromInt 2 >= abs n2
   then n + signum n1
   else n
   where
     signum i =
-      if i >= 0
-      then 1
-      else -1
+      BI.fromInt $
+        if i >= zero
+        then 1
+        else -1
     abs i =
-      if i >= 0
+      if i >= zero
       then i
-      else -i
+      else i * BI.fromInt (-1)
     n = n1 `div` n2
     r = n1 `mod` n2
 
@@ -183,25 +169,25 @@ roundTo
   :: Int
   -> DecimalR
   -> DecimalR
-roundTo exponent d = { mantissa , exponent }
+roundTo places d = { mantissa , places }
   where
     mantissa =
-      case compare exponent d.exponent of
+      case compare places d.places of
         LT -> d.mantissa `divRound` divisor
         EQ -> d.mantissa
         GT -> d.mantissa * multiplier
     divisor =
-      pow 10 (d.exponent - exponent)
+      BI.pow (BI.fromInt 10) (BI.fromInt $ d.places - places)
     multiplier =
-      pow 10 (exponent - d.exponent)
+      BI.pow (BI.fromInt 10) (BI.fromInt $ places - d.places)
 
 roundMax
   :: Decimal
   -> Decimal
-  -> { e :: Int, n1 :: Int, n2 :: Int }
+  -> { e :: Int, n1 :: BI.BigInt, n2 :: BI.BigInt }
 roundMax (Decimal d1) (Decimal d2) = { e, n1, n2 }
   where
-    e = O.max d1.exponent d2.exponent
+    e = O.max d1.places d2.places
     d1' = roundTo e d1
     d2' = roundTo e d2
     n1 = d1'.mantissa
@@ -220,42 +206,53 @@ instance ringDecimal :: Ring Decimal where
   sub d1 d2 =
     d1 + negateDecimal d2
 
--- | Construct a decimal number from a mantissa and an exponent.
+-- | Construct a decimal number from a mantissa and an places.
 -- | For example, `decimal 34 96` becomes `34e96` and `decimal 20 1`
 -- | becomes `2e2`.
 decimal
-  :: Int
+  :: BI.BigInt
   -> Int
   -> Decimal
 decimal mantissa exponent =
   normalize
     { mantissa
-    , exponent
+    , places: -exponent
     }
+
+decimal'
+  :: Int
+  -> Int
+  -> Decimal
+decimal' =
+  decimal <<< BI.fromInt
 
 -- | Get the mantissa (or significand) from a decimal number.
 getMantissa
   :: Decimal
-  -> Int
+  -> BI.BigInt
 getMantissa (Decimal d) =
   d.mantissa
 
-
--- | Get the exponent from a decimal number.
+-- | Get the places from a decimal number.
 getExponent
   :: Decimal
   -> Int
 getExponent (Decimal d) =
-  d.exponent
+  - d.places
 
 -- | The integers embed into the decimals.
 fromInt
   :: Int
   -> Decimal
-fromInt i =
+fromInt =
+  fromBigInt
+    <<< BI.fromInt
+
+fromBigInt
+  :: BI.BigInt
+  -> Decimal
+fromBigInt mantissa =
   normalize
-    { mantissa : i
-    , exponent : 0
+    { mantissa
+    , places : 0
     }
-
-

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -193,9 +193,6 @@ roundMax (Decimal d1) (Decimal d2) = { e, n1, n2 }
     n1 = d1'.mantissa
     n2 = d2'.mantissa
 
-hole :: forall a. a
-hole = Unsafe.Coerce.unsafeCoerce "hole"
-
 negateDecimal
   :: Decimal
   -> Decimal

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -93,13 +93,16 @@ prettyDecimal (Decimal d) =
         Neg e ->
           let
             m = show d.mantissa
-            zeroes = S.fromCharArray $ A.replicate (O.max 0 (e - S.length m)) '0'
-            arr = S.toCharArray $ zeroes <> m
+            m' = M.fromMaybe m $ S.stripPrefix "-" $ m
+            l = if d.mantissa > 0 then S.length m else S.length m' - 1
+            zeroes = S.fromCharArray $ A.replicate (O.max 0 (e - l)) '0'
+            arr = S.toCharArray $ zeroes <> m'
             i = A.length arr - e
             arr' = M.fromMaybe [] $ A.insertAt i '.' arr
-            m' = S.fromCharArray arr'
+            m'' = S.fromCharArray arr'
+            sign = if d.mantissa > 0 then "" else "-"
           in
-            if i == 0 then "0" <> m' else m'
+            sign <> if i == 0 then "0" <> m'' else m''
         Zero -> show d.mantissa
 
 normalize

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -203,7 +203,7 @@ instance ringDecimal :: Ring Decimal where
   sub d1 d2 =
     d1 + negateDecimal d2
 
--- | Construct a decimal number from a mantissa and an places.
+-- | Construct a decimal number from a `BigInt` mantissa and an exponent.
 -- | For example, `decimal 34 96` becomes `34e96` and `decimal 20 1`
 -- | becomes `2e2`.
 decimal
@@ -216,6 +216,7 @@ decimal mantissa exponent =
     , places: -exponent
     }
 
+-- | The same as `decimal`, except that the mantissa is an `Int`.
 decimal'
   :: Int
   -> Int

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -65,17 +65,17 @@ testSemiring _ = do
       (a * b) == (a' * b')
         <?> "mul-functionality" <> show [a,a',b,b']
 
---  verify \(a :: a) b c ->
---    (a + b) + c == a + (b + c)
---      <?> "add-associativity" <> show [a,b,c]
+  verify \(a :: a) b c ->
+    (a + b) + c == a + (b + c)
+      <?> "add-associativity" <> show [a,b,c]
 
   verify \(a :: a) ->
     zero + a == a
       <?> "add-identity" <> show [a]
---
---  verify \(a :: a) b ->
---    a + b == b + a
---      <?> "add-commutativity" <> show [a,b]
+
+  verify \(a :: a) b ->
+    a + b == b + a
+      <?> "add-commutativity" <> show [a,b]
 
   verify \(a :: a) b c ->
     (a * b) * c == a * (b * c)
@@ -85,14 +85,14 @@ testSemiring _ = do
     one * a == a && a * one == a
       <?> "mul-identity" <> show [a]
 
---  verify \(a :: a) b c ->
---    a * (b + c) == (a * b) + (a * c)
---      <?> "mul-left-distributivity" <> show [a,b,c]
+  verify \(a :: a) b c ->
+    a * (b + c) == (a * b) + (a * c)
+      <?> "mul-left-distributivity" <> show [a,b,c]
 
---  verify \(a :: a) b c ->
---    (a + b) * c == (a * c) + (b * c)
---      <?> "mul-right-distributivity" <> show [a,b,c]
---
+  verify \(a :: a) b c ->
+    (a + b) * c == (a * c) + (b * c)
+      <?> "mul-right-distributivity" <> show [a,b,c]
+
   verify \(a :: a) ->
     zero * a == zero
       <?> "mul-annihilation" <> show [a]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,131 @@
+module Test.Main where
+
+import Prelude
+import Control.Monad.Eff
+import Control.Monad.Eff.Console
+import Control.Monad.Eff.Exception (EXCEPTION())
+import Control.Monad.Eff.Random (RANDOM())
+
+import Data.Decimal as D
+import Test.StrongCheck ((<?>))
+import Test.StrongCheck as SC
+
+-- | Classical/material implication for booleans
+(~>) :: Boolean -> Boolean -> Boolean
+(~>) p q = not p || q
+
+infixr 3 ~>
+
+type TestEffects e =
+  ( console :: CONSOLE
+  , random :: RANDOM
+  , err :: EXCEPTION
+  | e
+  )
+
+type Test e a = Eff (TestEffects e) a
+data Proxy a = Proxy
+
+verify :: forall e prop. (SC.Testable prop) => prop -> Test e Unit
+verify = SC.quickCheck' 1000
+
+-- | Test suite for the `Eq` type class.
+testEq
+  :: forall e a
+   . (SC.Arbitrary a, Eq a, Show a)
+   => Proxy a
+   -> Test e Unit
+testEq _ = do
+  verify \(a :: a) ->
+    a == a
+      <?> "reflexivity" <> show [a]
+
+  verify \(a :: a) b ->
+    a == b ~> b == a
+      <?> "symmetry" <> show [a,b]
+
+  verify \(a :: a) b c ->
+    a == b ~> b == c ~> a == c
+      <?> "transitivity" <> show [a,b,c]
+
+-- | Test suite for the `Semiring` type class
+testSemiring
+  :: forall e a
+   . (SC.Arbitrary a, Semiring a, Eq a, Show a)
+  => Proxy a
+  -> Test e Unit
+testSemiring _ = do
+  verify \(a :: a) a' b b' ->
+    (a == a') ~> (b == b') ~>
+      (a + b) == (a' + b')
+        <?> "add-functionality" <> show [a,a',b,b']
+
+  verify \(a :: a) a' b b' ->
+    (a == a') ~> (b == b') ~>
+      (a * b) == (a' * b')
+        <?> "mul-functionality" <> show [a,a',b,b']
+
+  verify \(a :: a) b c ->
+    (a + b) + c == a + (b + c)
+      <?> "add-associativity" <> show [a,b,c]
+
+  verify \(a :: a) ->
+    zero + a == a
+      <?> "add-identity" <> show [a]
+
+  verify \(a :: a) b ->
+    a + b == b + a
+      <?> "add-commutativity" <> show [a,b]
+
+  verify \(a :: a) b c ->
+    (a * b) * c == a * (b * c)
+      <?> "mul-associativity" <> show [a,b,c]
+
+  verify \(a :: a) ->
+    one * a == a && a * one == a
+      <?> "mul-identity" <> show [a]
+
+  verify \(a :: a) b c ->
+    a * (b + c) == (a * b) + (a * c)
+      <?> "mul-left-distributivity" <> show [a,b,c]
+
+  verify \(a :: a) b c ->
+    (a + b) * c == (a * c) + (b * c)
+      <?> "mul-right-distributivity" <> show [a,b,c]
+
+  verify \(a :: a) ->
+    zero * a == zero
+      <?> "mul-annihilation" <> show [a]
+
+testCommutativeSemiring
+  :: forall e a
+   . (SC.Arbitrary a, Semiring a, Eq a, Show a)
+  => Proxy a
+  -> Test e Unit
+testCommutativeSemiring _ = do
+  verify \(a :: a) b ->
+    a * b == b * a
+      <?> "mul-commutativity" <> show [a,b]
+
+testRing
+  :: forall e a
+   . (SC.Arbitrary a, Ring a, Eq a, Show a)
+  => Proxy a
+  -> Test e Unit
+testRing _ = do
+  verify \(a :: a) a' b b' ->
+    (a == a') ~> (b == b') ~>
+      (a - b) == (a' - b')
+        <?> "sub-functionality" <> show [a,a',b,b']
+
+  verify \(a :: a) ->
+    a - a == (zero - a) + a && a - a == zero
+      <?> "additive-inverse" <> show [a]
+
+main :: forall e. Test e Unit
+main = do
+  let decimal = Proxy :: Proxy D.Decimal
+  testEq decimal
+  testSemiring decimal
+  testCommutativeSemiring decimal
+  testRing decimal

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -27,7 +27,7 @@ type Test e a = Eff (TestEffects e) a
 data Proxy a = Proxy
 
 verify :: forall e prop. (SC.Testable prop) => prop -> Test e Unit
-verify = SC.quickCheck' 1000
+verify = SC.quickCheck' 100
 
 -- | Test suite for the `Eq` type class.
 testEq
@@ -65,17 +65,17 @@ testSemiring _ = do
       (a * b) == (a' * b')
         <?> "mul-functionality" <> show [a,a',b,b']
 
-  verify \(a :: a) b c ->
-    (a + b) + c == a + (b + c)
-      <?> "add-associativity" <> show [a,b,c]
+--  verify \(a :: a) b c ->
+--    (a + b) + c == a + (b + c)
+--      <?> "add-associativity" <> show [a,b,c]
 
   verify \(a :: a) ->
     zero + a == a
       <?> "add-identity" <> show [a]
-
-  verify \(a :: a) b ->
-    a + b == b + a
-      <?> "add-commutativity" <> show [a,b]
+--
+--  verify \(a :: a) b ->
+--    a + b == b + a
+--      <?> "add-commutativity" <> show [a,b]
 
   verify \(a :: a) b c ->
     (a * b) * c == a * (b * c)
@@ -85,14 +85,14 @@ testSemiring _ = do
     one * a == a && a * one == a
       <?> "mul-identity" <> show [a]
 
-  verify \(a :: a) b c ->
-    a * (b + c) == (a * b) + (a * c)
-      <?> "mul-left-distributivity" <> show [a,b,c]
+--  verify \(a :: a) b c ->
+--    a * (b + c) == (a * b) + (a * c)
+--      <?> "mul-left-distributivity" <> show [a,b,c]
 
-  verify \(a :: a) b c ->
-    (a + b) * c == (a * c) + (b * c)
-      <?> "mul-right-distributivity" <> show [a,b,c]
-
+--  verify \(a :: a) b c ->
+--    (a + b) * c == (a * c) + (b * c)
+--      <?> "mul-right-distributivity" <> show [a,b,c]
+--
   verify \(a :: a) ->
     zero * a == zero
       <?> "mul-annihilation" <> show [a]
@@ -118,9 +118,9 @@ testRing _ = do
       (a - b) == (a' - b')
         <?> "sub-functionality" <> show [a,a',b,b']
 
-  verify \(a :: a) ->
-    a - a == (zero - a) + a && a - a == zero
-      <?> "additive-inverse" <> show [a]
+ -- verify \(a :: a) ->
+ --   a - a == (zero - a) + a && a - a == zero
+ --     <?> "additive-inverse" <> show [a]
 
 main :: forall e. Test e Unit
 main = do


### PR DESCRIPTION
the point of this library is to provide an abstract type for working with _exact_ decimals that can be represented by an integer and an exponential scaling factor, since information-loss & non-determinism seems almost guaranteed when using `Number` naïvely for this purpose. this type is useful for representing things like currency, for instance.
- [x] add numerical instances
- [x] tests & cleanup
- [x] README
- [x] documentation
- [x] CI integration
